### PR TITLE
#53: Metadata

### DIFF
--- a/app/lib/testing/__init__.py
+++ b/app/lib/testing/__init__.py
@@ -8,7 +8,7 @@ from testcontainers import postgres
 
 from app import data
 
-log = structlog.get_logger()
+log: structlog.stdlib.BoundLogger = structlog.get_logger()
 
 
 def find_free_port():
@@ -49,6 +49,8 @@ class TestPostgresStorage:
 
         for migration_filename in migrations:
             data = pathlib.Path(migrations_dir, migration_filename).read_text()
+            # there should be no placeholders in migrations
+            data = data.replace("%", "%%")
             self.storage.exec(data, [])
 
     def clear(self):

--- a/postgres/migrations/V001__common+rawdata.sql
+++ b/postgres/migrations/V001__common+rawdata.sql
@@ -7,7 +7,7 @@ DROP SCHEMA IF EXISTS rawdata CASCADE ;
 ------ Common ---------------------------------------------
 CREATE SCHEMA common ;
 
-COMMENT ON SCHEMA common IS 'The schema contains the common Leda tables' ;
+COMMENT ON SCHEMA common IS 'Common Leda tables' ;
 
 
 -----------------------------------------------------------
@@ -65,7 +65,7 @@ COMMENT ON COLUMN common.users.email IS 'User email' ;
 -------- Raw data -----------------------------------------
 CREATE SCHEMA rawdata;
 
-COMMENT ON SCHEMA rawdata IS 'The schema is a container for the orginal tables from different sources' ;
+COMMENT ON SCHEMA rawdata IS 'Container for the orginal tables from different sources' ;
 
 
 

--- a/postgres/migrations/V003__functions.sql
+++ b/postgres/migrations/V003__functions.sql
@@ -98,4 +98,35 @@ COMMENT ON FUNCTION public.sphdist (double precision, double precision, double p
 IS 'Angular separation in DEGREES between 2 points on sphere. The coordinates (RA1,Dec1) and (RA2,Dec2) are in DEGREES.' ;
 
 
+--------------------------------------------------------------
+---------- Check if string is JSON ---------------------------
+--------------------------------------------------------------
+-- in Postgresql 16 there is special function for that purpose
+--
+-- This solution is from
+-- https://stackoverflow.com/questions/2583472/regex-to-validate-json
+--
+-- Unfortunatly, the improved solution by Gino Pane does not work in Postgres
+--        (?(DEFINE)
+--           (?<number>   -? (?= [1-9]|0(?!\d) ) \d+ (\.\d+)? ([eE] [+-]? \d+)? )
+--           (?<boolean>   true | false | null )
+--           (?<string>    " ([^"\n\r\t\\\\]* | \\\\ ["\\\\bfnrt\/] | \\\\ u [0-9a-f]{4} )* " )
+--           (?<array>     \[  (?:  (?&json)  (?: , (?&json)  )*  )?  \s* \] )
+--           (?<pair>      \s* (?&string) \s* : (?&json)  )
+--           (?<object>    \{  (?:  (?&pair)  (?: , (?&pair)  )*  )?  \s* \} )
+--           (?<json>   \s* (?: (?&number) | (?&boolean) | (?&string) | (?&array) | (?&object) ) \s* )
+--        )
+--        \A (?&json) \Z
+--
+-- I have implemented simplified solution by @cjbarth
+-- [{\[]{1}([,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t]|".*?")+[}\]]{1}
+
+CREATE OR REPLACE FUNCTION
+  public.isjson( str text )
+RETURNS boolean
+AS $$
+  SELECT str ~* '[{\[]{1}([,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t]|".*?")+[}\]]{1}' ;
+$$  LANGUAGE sql COST 100 IMMUTABLE RETURNS NULL ON NULL INPUT PARALLEL SAFE
+;
+
 COMMIT ;

--- a/postgres/migrations/V005__meta.sql
+++ b/postgres/migrations/V005__meta.sql
@@ -1,0 +1,163 @@
+BEGIN ;
+
+DROP SCHEMA IF EXISTS meta CASCADE;
+
+----------------------------------------------------
+-- Meta data schema --------------------------------
+
+CREATE SCHEMA meta ;
+
+COMMENT ON SCHEMA meta IS 'Metadata' ;
+
+
+---------------------------------------------------
+-- Column metadata --------------------------------
+CREATE OR REPLACE VIEW meta.column_info AS
+WITH
+  s1 AS (
+  SELECT
+    table_schema	AS schema_name
+  , table_name
+  , column_name
+  , pg_catalog.col_description( format('%s.%s',table_schema,table_name)::regclass, ordinal_position )::text	AS str_comment
+  FROM 
+    information_schema.columns
+  WHERE
+        table_schema <> 'pg_catalog'
+    and table_schema <> 'information_schema'
+    and table_schema !~ 'pg_toast'
+  )
+SELECT
+  schema_name
+, table_name
+, column_name
+, CASE WHEN isjson(str_comment)
+    THEN str_comment::json
+    ELSE json_build_object('description', str_comment )
+  END	AS param
+FROM s1
+;
+
+COMMENT ON VIEW meta.column_info IS 'Column Metadata' ;
+COMMENT ON COLUMN meta.column_info.schema_name IS 'Schema name' ;
+COMMENT ON COLUMN meta.column_info.table_name IS 'Table name' ;
+COMMENT ON COLUMN meta.column_info.column_name IS 'Column name' ;
+COMMENT ON COLUMN meta.column_info.param IS 'Metadata in JSON format' ;
+
+
+---------------------------------------------------
+-- Table metadata ---------------------------------
+CREATE OR REPLACE VIEW meta.table_info AS
+WITH
+  s1 AS (
+  SELECT
+    table_schema	AS schema_name
+  , table_name
+  , pg_catalog.obj_description(format('%s.%s',table_schema,table_name)::regclass, 'pg_class')::text	AS str_comment
+  FROM 
+    information_schema.tables
+  WHERE
+        table_schema <> 'pg_catalog'
+    and table_schema <> 'information_schema'
+    and table_schema !~ 'pg_toast'
+  )
+SELECT
+  schema_name
+, table_name
+, CASE WHEN isjson(str_comment)
+    THEN str_comment::json
+    ELSE json_build_object('description', str_comment )
+  END	AS param
+FROM s1
+;
+
+COMMENT ON VIEW meta.table_info IS 'Table Metadata' ;
+COMMENT ON COLUMN meta.table_info.schema_name IS 'Schema name' ;
+COMMENT ON COLUMN meta.table_info.table_name IS 'Table name' ;
+COMMENT ON COLUMN meta.table_info.param IS 'Metadata in JSON format' ;
+
+
+---------------------------------------------------
+-- Schema metadata --------------------------------
+CREATE OR REPLACE VIEW meta.schema_info AS
+WITH
+  s1 AS (
+  SELECT
+    schema_name
+  , pg_catalog.obj_description(schema_name::regnamespace, 'pg_namespace')::text	AS str_comment
+  FROM 
+    information_schema.schemata
+  WHERE
+        schema_name <> 'pg_catalog'
+    and schema_name <> 'information_schema'
+    and schema_name !~ 'pg_toast'
+  )
+SELECT
+  schema_name
+, CASE WHEN isjson(str_comment)
+    THEN str_comment::json
+    ELSE json_build_object('description', str_comment )
+  END	AS param
+FROM s1
+;
+
+COMMENT ON VIEW meta.schema_info IS 'Schema Metadata' ;
+COMMENT ON COLUMN meta.schema_info.schema_name IS 'Schema name' ;
+COMMENT ON COLUMN meta.schema_info.param IS 'Metadata in JSON format' ;
+
+
+---------------------------------------------------
+-- Function to write metadata ---------------------
+
+CREATE OR REPLACE FUNCTION 
+  meta.setparams( schema_name text, table_name text, column_name text, param json )
+RETURNS void
+AS $$
+  DECLARE
+    str_comment text := param::text ;
+  BEGIN
+    EXECUTE format( 'COMMENT ON COLUMN %I.%I.%I IS %L', schema_name, table_name, column_name, str_comment ) ;
+  END ;
+$$  LANGUAGE plpgsql COST 100 VOLATILE STRICT PARALLEL UNSAFE
+;
+
+CREATE OR REPLACE FUNCTION 
+  meta.setparams( schema_name text, table_name text, param json )
+RETURNS void
+AS $$
+  DECLARE
+    str_comment text := param::text ;
+    TabType char ;
+  BEGIN
+    SELECT c.relkind INTO TabType 
+    FROM
+      pg_catalog.pg_class AS c
+      LEFT JOIN pg_catalog.pg_namespace AS n ON (n.oid = c.relnamespace)
+    WHERE
+          n.nspname=schema_name
+      and c.relname=table_name
+    ;
+
+    CASE WHEN TabType='r' THEN EXECUTE format( 'COMMENT ON TABLE %I.%I IS %L', schema_name, table_name, str_comment ) ;
+         WHEN TabType='v' THEN EXECUTE format( 'COMMENT ON VIEW %I.%I IS %L', schema_name, table_name, str_comment ) ;
+         WHEN TabType='m' THEN EXECUTE format( 'COMMENT ON MATERIALIZED VIEW %I.%I IS %L', schema_name, table_name, str_comment ) ;
+    END CASE;
+  END ;
+$$  LANGUAGE plpgsql COST 100 VOLATILE STRICT PARALLEL UNSAFE
+;
+
+CREATE OR REPLACE FUNCTION 
+  meta.setparams( schema_name text, param json )
+RETURNS void
+AS $$
+  DECLARE
+    str_comment text := param::text ;
+  BEGIN
+    EXECUTE format( 'COMMENT ON SCHEMA %I IS %L', schema_name, str_comment ) ;
+  END ;
+$$  LANGUAGE plpgsql COST 100 VOLATILE STRICT PARALLEL UNSAFE
+;
+
+
+
+COMMIT ;


### PR DESCRIPTION
Метаданные поддерживаются на основе механизма комментариев в PostgreSQL.
Комментарий записывается в виде JSON-строки.

Для просмотре метаданных созданы 3 представления:
meta.column_info
meta.table_info
meta.schema_info

Для записи новых метаданных нужно пользоваться функциями:
meta.setparams( schema_name text, table_name text, column_name text, param json )
meta.setparams( schema_name text, table_name text, param json )
meta.setparams( schema_name text, param json )