### PR TITLE
#2: fixed Layer0 repo to maintain consistency during insertion

### DIFF
--- a/app/data/interface/layer0_repository.py
+++ b/app/data/interface/layer0_repository.py
@@ -1,20 +1,20 @@
 import abc
-from typing import Any
 
 import psycopg
 
+from app.data import model
 from app.data.interface import transactional
 
 
 class Layer0Repository(transactional.Transactional):
     @abc.abstractmethod
-    def create_table(
-        self, schema: str, name: str, fields: list[tuple[str, str]], tx: psycopg.Transaction | None = None
-    ):
+    def create_table(self, data: model.Layer0Creation, tx: psycopg.Transaction | None = None) -> str:
         raise NotImplementedError("not implemented")
 
     @abc.abstractmethod
-    def insert_raw_data(
-        self, schema: str, table_name: str, raw_data: list[dict[str, Any]], tx: psycopg.Transaction | None = None
-    ) -> None:
+    def insert_raw_data(self, data: model.Layer0RawData, tx: psycopg.Transaction | None = None) -> None:
+        raise NotImplementedError("not implemented")
+
+    @abc.abstractmethod
+    def table_exists(self, schema: str, table_name: str) -> bool:
         raise NotImplementedError("not implemented")

--- a/app/data/model/__init__.py
+++ b/app/data/model/__init__.py
@@ -1,17 +1,10 @@
 import datetime
 from dataclasses import dataclass
 
+from app.data.model.common import Bibliography
+from app.data.model.layer0 import ColumnDescription, Layer0Creation, Layer0RawData
 from app.data.model.task import Task
 from app.lib.queue import TaskStatus
-
-
-@dataclass
-class Bibliography:
-    bibcode: str
-    year: int
-    author: list[str]
-    title: str
-    id: int | None = None
 
 
 @dataclass

--- a/app/data/model/common.py
+++ b/app/data/model/common.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Bibliography:
+    bibcode: str
+    year: int
+    author: list[str]
+    title: str
+    id: int | None = None

--- a/app/data/model/layer0.py
+++ b/app/data/model/layer0.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+import pandas
+
+from app.data.model import common
+
+
+@dataclass
+class ColumnDescription:
+    name: str
+    data_type: str
+    unit: str | None = None  # TODO: validate that the unit is one that we know how to transform
+    description: str | None = None
+
+
+@dataclass
+class Layer0Creation:
+    """
+    Metadata about the table to upload to layer 0
+
+    Args:
+        `table_name`: name of the table that will be written into database
+        `column_descriptions`: information about each column
+        `bibliography`: bibliographic information
+        `comment`: description of the table
+    """
+
+    table_name: str
+    column_descriptions: list[ColumnDescription]
+    bibliography: common.Bibliography
+    comment: str | None = None
+
+
+@dataclass
+class Layer0RawData:
+    table_name: str
+    data: pandas.DataFrame

--- a/app/data/repositories/layer0_repository.py
+++ b/app/data/repositories/layer0_repository.py
@@ -1,40 +1,77 @@
-from typing import Any, final
+import json
+from typing import final
 
 import psycopg
 import structlog
 
-from app.data import interface, template
+from app.data import interface, model, template
 from app.lib.storage import postgres
+
+RAWDATA_SCHEMA = "rawdata"
 
 
 @final
 class Layer0Repository(interface.Layer0Repository):
-    def __init__(self, storage: postgres.PgStorage, logger: structlog.BoundLogger) -> None:
+    def __init__(self, storage: postgres.PgStorage, logger: structlog.stdlib.BoundLogger) -> None:
         self._logger = logger
         self._storage = storage
 
     def with_tx(self) -> psycopg.Transaction:
         return self._storage.with_tx()
 
-    def create_table(
-        self,
-        schema: str,
-        name: str,
-        fields: list[tuple[str, str]],
-        tx: psycopg.Transaction | None = None,
-    ) -> None:
+    def create_table(self, data: model.Layer0Creation, tx: psycopg.Transaction | None = None) -> str:
+        """
+        Creates table, writes metadata and returns string that identifies the table for
+        further requests.
+        """
+        # TODO: use tx or new transaction here
+        fields = []
+        comment_queries = []
+
+        for column_descr in data.column_descriptions:
+            fields.append((column_descr.name, column_descr.data_type))
+            comment_queries.append(
+                template.render_query(
+                    template.ADD_COLUMN_COMMENT,
+                    schema=RAWDATA_SCHEMA,
+                    table_name=data.table_name,
+                    column_name=column_descr.name,
+                    params=json.dumps(
+                        {
+                            "description": column_descr.description,
+                            "unit": column_descr.unit,
+                        }
+                    ),
+                )
+            )
+
         self._storage.exec(
-            template.CREATE_TABLE.render(
-                schema=schema,
-                name=name,
+            template.render_query(
+                template.CREATE_TABLE,
+                schema=RAWDATA_SCHEMA,
+                name=data.table_name,
                 fields=fields,
-            ),
-            [],
-            tx,
+            )
         )
 
+        if data.comment is not None:
+            self._storage.exec(
+                template.render_query(
+                    template.ADD_TABLE_COMMENT,
+                    schema=RAWDATA_SCHEMA,
+                    table_name=data.table_name,
+                    params=json.dumps({"description": data.comment}),
+                ),
+                tx=tx,
+            )
+
+        for query in comment_queries:
+            self._storage.exec(query, tx=tx)
+
     def insert_raw_data(
-        self, schema: str, table_name: str, raw_data: list[dict[str, Any]], tx: psycopg.Transaction | None = None
+        self,
+        data: model.Layer0RawData,
+        tx: psycopg.Transaction | None = None,
     ) -> None:
         """
         This method puts everything in parameters for prepared statement. This should not be a big
@@ -43,37 +80,37 @@ class Layer0Repository(interface.Layer0Repository):
 
         Also the contract of this method requires all dicts to have the same set of keys.
         """
-        if not raw_data:
-            self._logger.warn("trying to insert 0 rows into the table", table=f"{schema}.{table_name}")
+
+        if len(data.data) == 0:
+            self._logger.warn("trying to insert 0 rows into the table", table=f"{RAWDATA_SCHEMA}.{data.table_name}")
             return
 
         params = []
         objects = []
-        fields = raw_data[0].keys()
+        fields = data.data.columns
 
-        for row in raw_data:
+        for row in data.data.to_dict(orient="records"):
             obj = {}
             for field in fields:
                 value = row[field]
-                try:
-                    params.append(value.item())
-                except AttributeError:
-                    params.append(value)
+                params.append(value)
                 obj[field] = "%s"
 
             objects.append(obj)
 
-        query = template.INSERT_RAW_DATA.render(schema=schema, table=table_name, fields=fields, objects=objects)
+        query = template.INSERT_RAW_DATA.render(
+            schema=RAWDATA_SCHEMA, table=data.table_name, fields=fields, objects=objects
+        )
 
         self._storage.exec(
             query,
-            params,
-            tx,
+            params=params,
+            tx=tx,
         )
 
     def table_exists(self, schema: str, table_name: str) -> bool:
         try:
-            self._storage.exec(f"SELECT 1 FROM {schema}.{table_name}", [])
+            self._storage.exec(f"SELECT 1 FROM {schema}.{table_name}")
         except psycopg.errors.UndefinedTable:
             return False
 

--- a/app/data/repositories/layer1_repository.py
+++ b/app/data/repositories/layer1_repository.py
@@ -18,7 +18,7 @@ class Layer1Repository(interface.Layer1Repository):
 
     def create_objects(self, n: int, tx: psycopg.Transaction | None = None) -> list[int]:
         query = template.NEW_OBJECTS.render(n=n)
-        rows = self._storage.query(query, [], tx)
+        rows = self._storage.query(query, tx=tx)
 
         return [int(row.get("id")) for row in rows]
 
@@ -27,12 +27,12 @@ class Layer1Repository(interface.Layer1Repository):
         for designation in designations:
             params.extend([designation.pgc, designation.design, designation.bib])
 
-        self._storage.exec(template.NEW_DESIGNATIONS.render(objects=designations), params, tx)
+        self._storage.exec(template.NEW_DESIGNATIONS.render(objects=designations), params=params, tx=tx)
 
     def get_designations(
         self, pgc: int, offset: int, limit: int, tx: psycopg.Transaction | None = None
     ) -> list[model.Designation]:
-        rows = self._storage.query(template.GET_DESIGNATIONS, [pgc, offset, limit], tx)
+        rows = self._storage.query(template.GET_DESIGNATIONS, params=[pgc, offset, limit], tx=tx)
 
         return [model.Designation(**row) for row in rows]
 
@@ -43,4 +43,4 @@ class Layer1Repository(interface.Layer1Repository):
         for coordinate in coordinates:
             params.extend([coordinate.pgc, coordinate.ra, coordinate.dec, coordinate.bib])
 
-        self._storage.exec(template.NEW_COORDINATES.render(objects=coordinates), params, tx)
+        self._storage.exec(template.NEW_COORDINATES.render(objects=coordinates), params=params, tx=tx)

--- a/app/data/template.py
+++ b/app/data/template.py
@@ -2,6 +2,13 @@ import jinja2
 
 # TODO: make a unified way for querying with templates
 
+
+def render_query(query_string: str, **kwargs) -> str:
+    tpl = jinja2.Environment(loader=jinja2.BaseLoader()).from_string(query_string)
+
+    return tpl.render(**kwargs)
+
+
 ONE_BIBLIOGRAPHY = """
 SELECT id, bibcode, year, author, title FROM common.bib
 WHERE id = %s
@@ -56,15 +63,22 @@ OFFSET %s
 LIMIT %s
 """
 
-CREATE_TABLE = jinja2.Environment(loader=jinja2.BaseLoader()).from_string(
-    """
+CREATE_TABLE = """
 CREATE TABLE {{ schema }}.{{ name }} (
     {% for field_name, field_type in fields %}
     {{field_name}} {{field_type}}{% if not loop.last %},{% endif %}
     {% endfor %}
 )
 """
-)
+
+# TODO: use meta.setparam
+ADD_COLUMN_COMMENT = """
+COMMENT ON COLUMN {{ schema }}.{{ table_name }}.{{ column_name }} IS '{{ params }}'
+"""
+
+ADD_TABLE_COMMENT = """
+COMMENT ON TABLE {{ schema }}.{{ table_name }} IS '{{ params }}'
+"""
 
 INSERT_RAW_DATA = jinja2.Environment(loader=jinja2.BaseLoader()).from_string(
     """

--- a/app/domain/interface.py
+++ b/app/domain/interface.py
@@ -28,5 +28,8 @@ class Actions(abc.ABC):
     def start_task(self, r: model.StartTaskRequest) -> model.StartTaskResponse:
         raise NotImplementedError("not implemented")
 
+    def debug_start_task(self, r: model.StartTaskRequest) -> model.StartTaskResponse:
+        raise NotImplementedError("not implemented")
+
     def get_task_info(self, r: model.GetTaskInfoRequest) -> model.GetTaskInfoResponse:
         raise NotImplementedError("not implemented")

--- a/app/domain/model/layer0/layer_0_meta.py
+++ b/app/domain/model/layer0/layer_0_meta.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from .biblio import Biblio
-from .coordinates.coordinate_descr import CoordinateDescr
-from .dataset import Dataset
-from .values.value_descr import ValueDescr
+from app.domain.model.layer0.biblio import Biblio
+from app.domain.model.layer0.coordinates.coordinate_descr import CoordinateDescr
+from app.domain.model.layer0.dataset import Dataset
+from app.domain.model.layer0.values.value_descr import ValueDescr
 
 
 @dataclass

--- a/app/domain/model/layer0/layer_0_model.py
+++ b/app/domain/model/layer0/layer_0_model.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 from pandas import DataFrame
 
-from .layer_0_meta import Layer0Meta
+from app.domain.model.layer0.layer_0_meta import Layer0Meta
 
 
 @dataclass

--- a/app/domain/model/task.py
+++ b/app/domain/model/task.py
@@ -27,4 +27,4 @@ class GetTaskInfoResponse:
     payload: dict[str, Any]
     start_time: datetime.datetime | None
     end_time: datetime.datetime | None
-    message: dict[str, Any]
+    message: dict[str, Any] | None

--- a/app/lib/storage/postgres/postgres_storage.py
+++ b/app/lib/storage/postgres/postgres_storage.py
@@ -36,7 +36,7 @@ DEFAULT_DUMPERS: list[tuple[type, type]] = [
 ]
 
 DEFAULT_ENUMS = [
-    (TaskStatus, "task_status"),
+    (TaskStatus, "common.task_status"),
 ]
 
 
@@ -83,7 +83,7 @@ class PgStorage:
 
             self._connection.close()
 
-    def exec(self, query: str, params: list[Any], tx: psycopg.Transaction | None = None) -> None:
+    def exec(self, query: str, *, params: list[Any] | None = None, tx: psycopg.Transaction | None = None) -> None:
         if params is None:
             params = []
         if self._connection is None:
@@ -96,7 +96,9 @@ class PgStorage:
         with storageutils.get_or_create_transaction(self._connection, tx):
             cursor.execute(query, params)
 
-    def query(self, query: str, params: list[Any], tx: psycopg.Transaction | None = None) -> list[rows.DictRow]:
+    def query(
+        self, query: str, *, params: list[Any] | None = None, tx: psycopg.Transaction | None = None
+    ) -> list[rows.DictRow]:
         if params is None:
             params = []
         if self._connection is None:
@@ -112,8 +114,10 @@ class PgStorage:
 
         return result_rows
 
-    def query_one(self, query: str, params: list[Any], tx: psycopg.Transaction | None = None) -> rows.DictRow:
-        result = self.query(query, params, tx)
+    def query_one(
+        self, query: str, *, params: list[Any] | None = None, tx: psycopg.Transaction | None = None
+    ) -> rows.DictRow:
+        result = self.query(query, params=params, tx=tx)
 
         if len(result) < 1:
             raise new_database_error("was unable to fetch one value")

--- a/app/lib/testing/postgres.py
+++ b/app/lib/testing/postgres.py
@@ -53,10 +53,10 @@ class TestPostgresStorage:
         connection.close()
 
     def clear(self):
-        self.storage.exec("TRUNCATE common.pgc CASCADE", [])
-        self.storage.exec("TRUNCATE common.bib CASCADE", [])
+        self.storage.exec("TRUNCATE common.pgc CASCADE")
+        self.storage.exec("TRUNCATE common.bib CASCADE")
         # note that this removes metadata about the schema.
-        self.storage.exec("DROP SCHEMA rawdata CASCADE; CREATE SCHEMA rawdata", [])
+        self.storage.exec("DROP SCHEMA rawdata CASCADE; CREATE SCHEMA rawdata")
 
     def get_storage(self) -> postgres.PgStorage:
         return self.storage

--- a/app/presentation/server/__init__.py
+++ b/app/presentation/server/__init__.py
@@ -46,6 +46,7 @@ routes = [
     (HTTPMETHOD_GET, "/api/v1/object/names", handlers.get_object_names),
     (HTTPMETHOD_GET, "/api/v1/pipeline/catalogs", handlers.search_catalogs),
     (HTTPMETHOD_POST, "/api/v1/task", handlers.start_task),
+    (HTTPMETHOD_POST, "/api/v1/debug/task", handlers.debug_start_task),
     (HTTPMETHOD_GET, "/api/v1/task", handlers.get_task_info),
 ]
 

--- a/app/presentation/server/handlers/__init__.py
+++ b/app/presentation/server/handlers/__init__.py
@@ -1,6 +1,7 @@
 from app.presentation.server.handlers.create_object import create_object
 from app.presentation.server.handlers.create_objects import create_objects
 from app.presentation.server.handlers.create_source import create_source
+from app.presentation.server.handlers.debug_start_task import debug_start_task
 from app.presentation.server.handlers.get_object_names import get_object_names
 from app.presentation.server.handlers.get_source import get_source
 from app.presentation.server.handlers.get_source_list import get_source_list
@@ -20,4 +21,5 @@ __all__ = [
     "search_catalogs",
     "start_task",
     "get_task_info",
+    "debug_start_task",
 ]

--- a/app/presentation/server/handlers/debug_start_task.py
+++ b/app/presentation/server/handlers/debug_start_task.py
@@ -1,0 +1,31 @@
+import dataclasses
+from typing import Any
+
+from aiohttp import web
+from aiohttp_apispec import docs, request_schema, response_schema
+from marshmallow import ValidationError
+
+from app import domain
+from app.domain.model.task import StartTaskRequest
+from app.lib.exceptions import new_validation_error
+from app.presentation.model import StartTaskRequestSchema, StartTaskResponseSchema
+
+
+@docs(
+    summary="Start processing task in debug mode",
+    tags=["tasks"],
+    description="Starts task synchronously.",
+)
+@request_schema(
+    StartTaskRequestSchema(),
+    example=dataclasses.asdict(StartTaskRequest("echo", {"sleep_time_seconds": 2})),
+)
+@response_schema(StartTaskResponseSchema(), 200)
+async def debug_start_task(actions: domain.Actions, r: web.Request) -> Any:
+    request_dict = await r.json()
+    try:
+        request = StartTaskRequestSchema().load(request_dict)
+    except ValidationError as e:
+        raise new_validation_error(str(e)) from e
+
+    return actions.debug_start_task(request)

--- a/postgres/migrations/V001__common.sql
+++ b/postgres/migrations/V001__common.sql
@@ -99,12 +99,12 @@ INSERT INTO common.datatype VALUES
 -----------------------------------------------------------
 --------- Tasks -------------------------------------------
 
-CREATE TYPE task_status AS ENUM('new', 'in_progress', 'failed', 'done');
+CREATE TYPE common.task_status AS ENUM('new', 'in_progress', 'failed', 'done');
 
 CREATE TABLE common.tasks (
   id	serial	PRIMARY KEY
 , task_name	text	NOT NULL
-, status	task_status	NOT NULL DEFAULT 'new'
+, status	common.task_status	NOT NULL DEFAULT 'new'
 , start_time	timestamp without time zone
 , end_time	timestamp without time zone
 , payload	jsonb
@@ -120,6 +120,7 @@ COMMENT ON COLUMN common.tasks.start_time IS 'Task start time';
 COMMENT ON COLUMN common.tasks.end_time IS 'Task end time';
 COMMENT ON COLUMN common.tasks.payload IS 'Data that was used to start the task';
 COMMENT ON COLUMN common.tasks.user_id IS 'User who started the task';
+COMMENT ON COLUMN common.tasks.message IS 'Some payload about the task or error message if it failed';
 
 CREATE OR REPLACE FUNCTION common.set_task_times() RETURNS trigger
     LANGUAGE plpgsql

--- a/postgres/migrations/V005__meta.sql
+++ b/postgres/migrations/V005__meta.sql
@@ -21,7 +21,7 @@ WITH
     table_schema	AS schema_name
   , table_name
   , column_name
-  , pg_catalog.col_description( format('%s.%s',table_schema,table_name)::regclass, ordinal_position )::text	AS str_comment
+  , pg_catalog.col_description(CONCAT(table_schema, '.', table_name)::regclass::oid, ordinal_position)::text	AS str_comment
   FROM 
     information_schema.columns
   WHERE
@@ -55,7 +55,7 @@ WITH
   SELECT
     table_schema	AS schema_name
   , table_name
-  , pg_catalog.obj_description(format('%s.%s',table_schema,table_name)::regclass, 'pg_class')::text	AS str_comment
+  , pg_catalog.obj_description(CONCAT(table_schema, '.', table_name)::regclass, 'pg_class')::text	AS str_comment
   FROM 
     information_schema.tables
   WHERE

--- a/tests/integration/download_vizier_table_test.py
+++ b/tests/integration/download_vizier_table_test.py
@@ -25,10 +25,14 @@ class RawDataTest(unittest.TestCase):
 
     @mock.patch("astroquery.vizier.VizierClass")
     def test_table_downloading_simple(self, vizier_mock):
-        test_table = table.Table(names=("name", "ra", "dec"), dtype=("S2", "f4", "f4"))
-        test_table.meta = {"name": "test_table"}
-        test_table.add_row(("M333", 120.0, 10))
-        test_table.add_row(("M541", 90, -50))
+        test_table = table.Table(
+            names=("name", "ra", "dec"),
+            dtype=("str", "f4", "f4"),
+            descriptions=("test name descr", "test ra descr", "test dec descr"),
+        )
+        test_table.meta = {"name": "test_table", "description": "test descr"}
+        test_table.add_row(("D333", 120.0, 10))
+        test_table.add_row(("D541", 90, -50))
 
         vizier_mock.return_value.get_catalogs = mock.MagicMock(return_value=[test_table])
 
@@ -37,14 +41,32 @@ class RawDataTest(unittest.TestCase):
             tasks.DownloadVizierTableParams("test_catalog", "test_table"),
             structlog.get_logger(),
         )
-        rows = self.storage.get_storage().query("SELECT name, ra, dec FROM rawdata.data_vizier_test_table", [])
+        rows = self.storage.get_storage().query("SELECT name, ra, dec FROM rawdata.data_vizier_test_table")
         self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[0]["name"], "M333")
-        self.assertEqual(rows[1]["name"], "M541")
+        self.assertEqual(rows[0]["name"], "D333")
+        self.assertEqual(rows[1]["name"], "D541")
+
+        comment_rows = self.storage.get_storage().query(
+            "SELECT param FROM meta.table_info WHERE schema_name = 'rawdata' AND table_name = 'data_vizier_test_table'"
+        )
+        self.assertDictEqual(comment_rows[0]["param"], {"description": "test descr"})
+
+        comment_rows = self.storage.get_storage().query(
+            "SELECT param FROM meta.column_info WHERE schema_name = 'rawdata' AND table_name = 'data_vizier_test_table' AND column_name = 'name'"
+        )
+        self.assertDictEqual(comment_rows[0]["param"], {"description": "test name descr", "unit": "None"})
+        comment_rows = self.storage.get_storage().query(
+            "SELECT param FROM meta.column_info WHERE schema_name = 'rawdata' AND table_name = 'data_vizier_test_table' AND column_name = 'ra'"
+        )
+        self.assertDictEqual(comment_rows[0]["param"], {"description": "test ra descr", "unit": "None"})
+        comment_rows = self.storage.get_storage().query(
+            "SELECT param FROM meta.column_info WHERE schema_name = 'rawdata' AND table_name = 'data_vizier_test_table' AND column_name = 'dec'"
+        )
+        self.assertDictEqual(comment_rows[0]["param"], {"description": "test dec descr", "unit": "None"})
 
     @mock.patch("astroquery.vizier.VizierClass")
     def test_bad_column_names(self, vizier_mock):
-        test_table = table.Table(names=("name", "object-type"), dtype=("S2", "S2"))
+        test_table = table.Table(names=("name", "object-type"), dtype=("str", "str"))
         test_table.meta = {"name": "test_table"}
         test_table.add_row(("M333", "type1"))
         test_table.add_row(("M541", "type2"))
@@ -56,14 +78,14 @@ class RawDataTest(unittest.TestCase):
             tasks.DownloadVizierTableParams("test_catalog", "test_table"),
             structlog.get_logger(),
         )
-        rows = self.storage.get_storage().query("SELECT name, object_type FROM rawdata.data_vizier_test_table", [])
+        rows = self.storage.get_storage().query("SELECT name, object_type FROM rawdata.data_vizier_test_table")
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]["object_type"], "type1")
         self.assertEqual(rows[1]["object_type"], "type2")
 
     @mock.patch("astroquery.vizier.VizierClass")
     def test_nans_in_data(self, vizier_mock):
-        test_table = table.Table(names=("name", "ra", "dec"), dtype=("S2", "f4", "f4"))
+        test_table = table.Table(names=("name", "ra", "dec"), dtype=("str", "f4", "f4"))
         test_table.meta = {"name": "test_table"}
         test_table.add_row(("M333", np.NaN, 10))
         test_table.add_row(("M541", 90, -50))
@@ -75,13 +97,13 @@ class RawDataTest(unittest.TestCase):
             tasks.DownloadVizierTableParams("test_catalog", "test_table"),
             structlog.get_logger(),
         )
-        rows = self.storage.get_storage().query("SELECT name, ra, dec FROM rawdata.data_vizier_test_table", [])
+        rows = self.storage.get_storage().query("SELECT name, ra, dec FROM rawdata.data_vizier_test_table")
         self.assertEqual(len(rows), 2)
         self.assertTrue(np.isnan(rows[0]["ra"]))
 
     @mock.patch("astroquery.vizier.VizierClass")
     def test_caching_table(self, vizier_mock):
-        test_table = table.Table(names=("name", "ra", "dec"), dtype=("S2", "f4", "f4"))
+        test_table = table.Table(names=("name", "ra", "dec"), dtype=("str", "f4", "f4"))
         test_table.meta = {"name": "test_table"}
         test_table.add_row(("M333", np.NaN, 10))
         test_table.add_row(("M541", 90, -50))
@@ -102,5 +124,5 @@ class RawDataTest(unittest.TestCase):
         )
 
         mock_vizier_class.get_catalogs.assert_called_once()
-        rows = self.storage.get_storage().query("SELECT * FROM rawdata.data_vizier_test_table", [])
+        rows = self.storage.get_storage().query("SELECT * FROM rawdata.data_vizier_test_table")
         self.assertEqual(len(rows), 2)


### PR DESCRIPTION
- added render query func into repository
- fixed parameters in storage exec and query methods a bit
- moved task_status to common schema
- fixed views in meta to use concat instead of format strings
- fixed tests correspondingly