### PR TITLE
Add optional reference_id field to layer0.tables

### DIFF
--- a/app/data/model/table.py
+++ b/app/data/model/table.py
@@ -42,6 +42,7 @@ class Layer0TableMeta:
     modification_dt: datetime.datetime | None = None
     description: str | None = None
     table_id: int | None = None
+    reference_id: str | None = None
 
 
 @dataclass
@@ -51,6 +52,7 @@ class Layer0TableListItem:
     num_fields: int
     modification_dt: datetime.datetime
     bibcode: str
+    reference_id: str | None = None
 
 
 @dataclass

--- a/app/data/repositories/layer0/tables.py
+++ b/app/data/repositories/layer0/tables.py
@@ -77,7 +77,7 @@ class Layer0TableRepository(postgres.TransactionalPGRepository):
         with self.with_tx():
             row = self._storage.query_one(
                 template.INSERT_TABLE_REGISTRY_ITEM,
-                params=[data.bibliography_id, data.table_name, data.datatype],
+                params=[data.bibliography_id, data.table_name, data.datatype, data.reference_id],
             )
             table_id = int(row.get("id"))
 
@@ -460,6 +460,7 @@ class Layer0TableRepository(postgres.TransactionalPGRepository):
             modification_dt,
             table_metadata["param"].get("description"),
             table_id=registry_item["id"],
+            reference_id=registry_item.get("reference_id"),
         )
 
     def update_column_metadata(self, table_name: str, column_description: model.ColumnDescription) -> None:
@@ -534,6 +535,7 @@ class Layer0TableRepository(postgres.TransactionalPGRepository):
             t.modification_dt,
             COALESCE(ti.param->>'description', '') AS description,
             b.code AS bibcode,
+            t.reference_id,
             (
                 SELECT COUNT(*)::int
                 FROM meta.column_info c
@@ -566,6 +568,7 @@ class Layer0TableRepository(postgres.TransactionalPGRepository):
                 num_fields=int(row["num_fields"]),
                 modification_dt=row["modification_dt"],
                 bibcode=row["bibcode"],
+                reference_id=row["reference_id"],
             )
             for row in rows
         ]

--- a/app/data/template.py
+++ b/app/data/template.py
@@ -29,8 +29,8 @@ LIMIT 1
 """
 
 INSERT_TABLE_REGISTRY_ITEM = """
-INSERT INTO layer0.tables (bib, table_name, datatype)
-VALUES (%s, %s, %s)
+INSERT INTO layer0.tables (bib, table_name, datatype, reference_id)
+VALUES (%s, %s, %s, %s)
 RETURNING id
 """
 

--- a/app/domain/adminapi/table_upload.py
+++ b/app/domain/adminapi/table_upload.py
@@ -113,6 +113,7 @@ class TableUploadManager:
                 bibliography_id=source_id,
                 datatype=enums.DataType(r.datatype),
                 description=r.description,
+                reference_id=r.reference_id,
             ),
         )
 
@@ -211,6 +212,8 @@ class TableUploadManager:
             raise RuntimeError(f"Table {r.table_name} has no ID")
 
         metadata = {"datatype": meta.datatype, "modification_dt": meta.modification_dt}
+        if meta.reference_id is not None:
+            metadata["reference_id"] = meta.reference_id
 
         progress = self.table_stats_cache.get().tables.get(r.table_name)
         if progress is None:

--- a/app/presentation/adminapi/interface.py
+++ b/app/presentation/adminapi/interface.py
@@ -114,6 +114,10 @@ class CreateTableRequest(WriteRequest):
     )
     datatype: enums.DataType
     description: str = pydantic.Field(description="Human-readable description of the table")
+    reference_id: str | None = pydantic.Field(
+        default=None,
+        description="Optional external reference identifier for linking to external systems",
+    )
 
 
 class CreateTableResponse(pydantic.BaseModel):

--- a/postgres/migrations/V050__layer0_tables_reference_id.sql
+++ b/postgres/migrations/V050__layer0_tables_reference_id.sql
@@ -1,0 +1,8 @@
+/* pgmigrate-encoding: utf-8 */
+
+-- Add optional reference_id column to layer0.tables for external system linking
+ALTER TABLE layer0.tables ADD COLUMN reference_id text;
+COMMENT ON COLUMN layer0.tables.reference_id IS 'Optional external reference identifier for linking to external systems';
+
+-- Add index for better query performance on reference_id
+CREATE INDEX ON layer0.tables (reference_id);

--- a/tests/integration/create_table_test.py
+++ b/tests/integration/create_table_test.py
@@ -101,3 +101,53 @@ class CreateTableTest(unittest.TestCase):
         meta = self.upload_manager.get_table(presentation.GetTableRequest(table_name=table_name))
         self.assertEqual(meta.description, "updated table description")
         self.assertEqual(meta.meta["datatype"], enums.DataType.PRELIMINARY)
+
+    def test_create_table_with_reference_id(self):
+        source_code = self.source_manager.create_source(
+            presentation.CreateSourceRequest(title="title", authors=["author"], year=2022)
+        ).code
+        table_name = "table_with_reference"
+
+        response, created = self.upload_manager.create_table(
+            presentation.CreateTableRequest(
+                table_name=table_name,
+                columns=[
+                    presentation.ColumnDescription(name="name", data_type=presentation.DatatypeEnum["text"]),
+                ],
+                bibcode=source_code,
+                datatype=enums.DataType.REGULAR,
+                description="test table with reference",
+                reference_id="external-table-id-12345",
+            )
+        )
+
+        self.assertTrue(created)
+        self.assertEqual(response.id, 1)
+
+        # Verify the reference_id was stored in the database
+        meta = self.upload_manager.get_table(presentation.GetTableRequest(table_name=table_name))
+        self.assertEqual(meta.meta.get("reference_id"), "external-table-id-12345")
+
+    def test_create_table_without_reference_id(self):
+        source_code = self.source_manager.create_source(
+            presentation.CreateSourceRequest(title="title", authors=["author"], year=2022)
+        ).code
+        table_name = "table_without_reference"
+
+        response, created = self.upload_manager.create_table(
+            presentation.CreateTableRequest(
+                table_name=table_name,
+                columns=[
+                    presentation.ColumnDescription(name="name", data_type=presentation.DatatypeEnum["text"]),
+                ],
+                bibcode=source_code,
+                datatype=enums.DataType.REGULAR,
+                description="test table without reference",
+            )
+        )
+
+        self.assertTrue(created)
+
+        # Verify the reference_id is None when not provided
+        meta = self.upload_manager.get_table(presentation.GetTableRequest(table_name=table_name))
+        self.assertIsNone(meta.meta.get("reference_id"))


### PR DESCRIPTION
- Add reference_id column to layer0.tables table via database migration
- Update Layer0TableMeta model to include reference_id field
- Add reference_id to CreateTableRequest API model
- Update table creation logic to handle reference_id
- Field is optional and nullable for external system linking